### PR TITLE
Removed InstantYAML from the list of useful links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ pointers to all things YAML.
 ## Links
 
 * http://yaml.org - The YAML web site
-* http://instantyaml.appspot.com/
 * http://www.yamllint.com/
 * http://yaml-online-parser.appspot.com/
 * http://data-lint.herokuapp.com/


### PR DESCRIPTION
The service is not available any more.